### PR TITLE
Fix Message Index retuned value in callisto query

### DIFF
--- a/database/bridge.go
+++ b/database/bridge.go
@@ -42,7 +42,7 @@ func (db *Db) SaveBridgeTransaction(tx *types.BridgeTransaction) (int64, error) 
 // It returns the transaction if found, or an error if not found.
 func (db *Db) GetBridgeTransaction(operationUniqueID string) (types.BridgeTransaction, error) {
 	stmt := `
-	SELECT operation_unique_id, height, user_initiated_hash, source_chain, destination_chain, sender, recipient, denom, amount
+	SELECT operation_unique_id, height, user_initiated_hash, msg_index, source_chain, destination_chain, sender, recipient, denom, amount
 	FROM bridge_transaction
 	WHERE operation_unique_id = $1::TEXT
 `
@@ -54,6 +54,7 @@ func (db *Db) GetBridgeTransaction(operationUniqueID string) (types.BridgeTransa
 		&bridgeTx.OperationUniqueID,
 		&bridgeTx.Height,
 		&bridgeTx.UserInitiatedHash,
+		&bridgeTx.MsgIndex,
 		&bridgeTx.SourceChain,
 		&bridgeTx.DestinationChain,
 		&bridgeTx.Sender,


### PR DESCRIPTION
## Description

Add Message Index to the returning values of the `GetBridgeTransaction` method, which supports multiple messages within a single transaction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/callisto/87)
<!-- Reviewable:end -->
