### PR TITLE
Bridge Parse Transactions Re-Scan CMD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ config.yaml
 
 # Coverage
 coverage.*
+
+# OS
+.DS_Store

--- a/cmd/parse/bridge/cmd.go
+++ b/cmd/parse/bridge/cmd.go
@@ -1,0 +1,20 @@
+package bridge
+
+import (
+	parsecmdtypes "github.com/forbole/juno/v6/cmd/parse/types"
+	"github.com/spf13/cobra"
+)
+
+// NewBridgeCmd returns the Cobra command that allows to fix all the things related to the bridge module
+func NewBridgeCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bridge",
+		Short: "Fix things related to the bridge module",
+	}
+
+	cmd.AddCommand(
+		txsCmd(parseConfig),
+	)
+
+	return cmd
+}

--- a/cmd/parse/bridge/txs.go
+++ b/cmd/parse/bridge/txs.go
@@ -48,7 +48,6 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 			}
 
 			// Log processing summary header
-			log.Info().Msg("=== Bridge Transaction Processing Summary ===")
 			log.Info().Int64("start_height", startHeight).Int64("end_height", endHeight).Int64("check_size", checkSize).Msg("starting bridge transaction processing")
 
 			bz, err := config.Cfg.GetBytes()
@@ -162,7 +161,6 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 				totalBlocksInserted += rangeBlocksInserted
 
 				// Log summary for this range
-				log.Info().Msg("--- Range Summary ---")
 				if rangeMessagesProcessed > 0 {
 					successRate := float64(rangeMessagesProcessed-rangeErrorCount) / float64(rangeMessagesProcessed) * 100
 					log.Info().Int64("range_start", rangeStart).Int64("range_end", rangeEnd).
@@ -184,15 +182,12 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 			// Log final summary
 			rangeCount := (endHeight - startHeight + checkSize - 1) / checkSize
 
-			log.Info().Msg("============================================")
-			log.Info().Msg("=== Final Summary ===")
 			log.Info().
 				Int64("total_ranges_processed", rangeCount).
 				Int("total_txs_processed", totalTxsProcessed).
 				Int("total_blocks_inserted", totalBlocksInserted).
 				Int("total_errors_encountered", totalErrorsEncountered).
 				Msg("processing complete")
-			log.Info().Msg("============================================")
 
 			return nil
 		},

--- a/cmd/parse/bridge/txs.go
+++ b/cmd/parse/bridge/txs.go
@@ -3,7 +3,6 @@ package bridge
 import (
 	"encoding/hex"
 	"fmt"
-	"os"
 	"sort"
 	"time"
 
@@ -48,35 +47,9 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 				splitHeight = 1000 // Default split height
 			}
 
-			// Create error log file
-			timestamp := time.Now().Format("2006-01-02_15-04-05")
-			errorLogFileName := fmt.Sprintf("bridge_errors_%d_%d_%s.log", startHeight, endHeight, timestamp)
-			errorLogFile, err := os.OpenFile(errorLogFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-			if err != nil {
-				return fmt.Errorf("failed to create error log file: %s", err)
-			}
-			defer errorLogFile.Close()
-
-			// Create summary log file
-			summaryLogFileName := fmt.Sprintf("bridge_summary_%d_%d_%s.log", startHeight, endHeight, timestamp)
-			summaryLogFile, err := os.OpenFile(summaryLogFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-			if err != nil {
-				return fmt.Errorf("failed to create summary log file: %s", err)
-			}
-			defer summaryLogFile.Close()
-
-			// Write header to summary log
-			headerMsg := "=== Bridge Transaction Processing Summary ===\n"
-			headerMsg += fmt.Sprintf("Start Height: %d\n", startHeight)
-			headerMsg += fmt.Sprintf("End Height: %d\n", endHeight)
-			headerMsg += fmt.Sprintf("Split Height: %d\n", splitHeight)
-			headerMsg += fmt.Sprintf("Started at: %s\n", time.Now().Format("2006-01-02 15:04:05"))
-			headerMsg += "============================================\n\n"
-			if _, err := summaryLogFile.WriteString(headerMsg); err != nil {
-				log.Error().Err(err).Msg("failed to write header to summary log file")
-			}
-
-			log.Info().Str("error_log", errorLogFileName).Str("summary_log", summaryLogFileName).Msg("log files created")
+			// Log processing summary header
+			log.Info().Msg("=== Bridge Transaction Processing Summary ===")
+			log.Info().Int64("start_height", startHeight).Int64("end_height", endHeight).Int64("split_height", splitHeight).Msg("starting bridge transaction processing")
 
 			bz, err := config.Cfg.GetBytes()
 			if err != nil {
@@ -171,18 +144,6 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 						if err != nil {
 							rangeErrorCount++
 							txHash := hex.EncodeToString(tx.Tx.Hash())
-							errorMsg := fmt.Sprintf("[%s] Height: %d | TxHash: %s | MsgIndex: %d | Error: %v\n",
-								time.Now().Format("2006-01-02 15:04:05"),
-								tx.Height,
-								txHash,
-								index,
-								err,
-							)
-
-							// Write to error log file
-							if _, writeErr := errorLogFile.WriteString(errorMsg); writeErr != nil {
-								log.Error().Err(writeErr).Msg("failed to write to error log file")
-							}
 
 							log.Error().Int64("height", tx.Height).Int("msg_index", index).
 								Str("tx_hash", txHash).
@@ -200,54 +161,38 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 				totalErrorsEncountered += rangeErrorCount
 				totalBlocksInserted += rangeBlocksInserted
 
-				// Write summary for this range
-				summaryMsg := fmt.Sprintf("--- Range: %d to %d ---\n", rangeStart, rangeEnd)
-				summaryMsg += fmt.Sprintf("Timestamp: %s\n", time.Now().Format("2006-01-02 15:04:05"))
-				summaryMsg += fmt.Sprintf("Duration: %s\n", rangeDuration.String())
-				summaryMsg += fmt.Sprintf("Transactions Found: %d\n", len(txs))
-				summaryMsg += fmt.Sprintf("Messages Processed: %d\n", rangeMessagesProcessed)
-				summaryMsg += fmt.Sprintf("Blocks Inserted: %d\n", rangeBlocksInserted)
-				summaryMsg += fmt.Sprintf("Errors Encountered: %d\n", rangeErrorCount)
+				// Log summary for this range
+				log.Info().Msg("--- Range Summary ---")
 				if rangeMessagesProcessed > 0 {
 					successRate := float64(rangeMessagesProcessed-rangeErrorCount) / float64(rangeMessagesProcessed) * 100
-					summaryMsg += fmt.Sprintf("Success Rate: %.2f%%\n", successRate)
+					log.Info().Int64("range_start", rangeStart).Int64("range_end", rangeEnd).
+						Int("txs_found", len(txs)).Int("messages_processed", rangeMessagesProcessed).
+						Int("blocks_inserted", rangeBlocksInserted).Int("errors", rangeErrorCount).
+						Float64("success_rate", successRate).
+						Str("duration", rangeDuration.String()).
+						Msg("finished processing height range")
 				} else {
-					summaryMsg += "Success Rate: N/A (no messages processed)\n"
+					log.Info().Int64("range_start", rangeStart).Int64("range_end", rangeEnd).
+						Int("txs_found", len(txs)).Int("messages_processed", rangeMessagesProcessed).
+						Int("blocks_inserted", rangeBlocksInserted).Int("errors", rangeErrorCount).
+						Str("success_rate", "N/A").
+						Str("duration", rangeDuration.String()).
+						Msg("finished processing height range")
 				}
-				summaryMsg += "\n"
-
-				if _, err := summaryLogFile.WriteString(summaryMsg); err != nil {
-					log.Error().Err(err).Msg("failed to write to summary log file")
-				}
-
-				log.Info().Int64("range_start", rangeStart).Int64("range_end", rangeEnd).
-					Int("txs", len(txs)).Int("errors", rangeErrorCount).
-					Str("duration", rangeDuration.String()).
-					Msg("finished processing height range")
 			}
 
-			// Write final summary
+			// Log final summary
 			rangeCount := (endHeight - startHeight + splitHeight - 1) / splitHeight
 
-			finalSummary := "============================================\n"
-			finalSummary += "=== Final Summary ===\n"
-			finalSummary += fmt.Sprintf("Completed at: %s\n", time.Now().Format("2006-01-02 15:04:05"))
-			finalSummary += fmt.Sprintf("Total Ranges Processed: %d\n", rangeCount)
-			finalSummary += fmt.Sprintf("Total Transactions Processed: %d\n", totalTxsProcessed)
-			finalSummary += fmt.Sprintf("Total Blocks Inserted: %d\n", totalBlocksInserted)
-			finalSummary += fmt.Sprintf("Total Errors Encountered: %d\n", totalErrorsEncountered)
-			finalSummary += "============================================\n"
-
-			if _, err := summaryLogFile.WriteString(finalSummary); err != nil {
-				log.Error().Err(err).Msg("failed to write final summary to log file")
-			}
-
+			log.Info().Msg("============================================")
+			log.Info().Msg("=== Final Summary ===")
 			log.Info().
-				Str("error_log", errorLogFileName).
-				Str("summary_log", summaryLogFileName).
-				Int("total_txs", totalTxsProcessed).
-				Int("total_errors", totalErrorsEncountered).
+				Int64("total_ranges_processed", rangeCount).
+				Int("total_txs_processed", totalTxsProcessed).
+				Int("total_blocks_inserted", totalBlocksInserted).
+				Int("total_errors_encountered", totalErrorsEncountered).
 				Msg("processing complete")
+			log.Info().Msg("============================================")
 
 			return nil
 		},

--- a/cmd/parse/bridge/txs.go
+++ b/cmd/parse/bridge/txs.go
@@ -1,0 +1,110 @@
+package bridge
+
+import (
+	"encoding/hex"
+	"fmt"
+	"sort"
+
+	tmctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/forbole/callisto/v4/database"
+	"github.com/forbole/callisto/v4/modules/bridge"
+	modulestypes "github.com/forbole/callisto/v4/modules/types"
+	"github.com/forbole/callisto/v4/utils"
+	parsecmdtypes "github.com/forbole/juno/v6/cmd/parse/types"
+	"github.com/forbole/juno/v6/types/config"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+// txsCmd returns the Cobra command allowing re-scan bridge transactions
+func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "txs",
+		Short: "Parse all the bridge transactions and overwrite the existing ones",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parseCtx, err := parsecmdtypes.GetParserContext(config.Cfg, parseConfig)
+			if err != nil {
+				return err
+			}
+
+			startHeight, err := cmd.Flags().GetInt64("start-height")
+			if err != nil {
+				return err
+			}
+
+			bz, err := config.Cfg.GetBytes()
+			if err != nil {
+				return err
+			}
+			bridgeCfg, err := bridge.ParseConfig(bz)
+			if err != nil {
+				return err
+			}
+
+			sources, err := modulestypes.BuildSources(config.Cfg.Node, utils.GetCodec())
+			if err != nil {
+				return err
+			}
+
+			// Get the database
+			db := database.Cast(parseCtx.Database)
+
+			// Build bridge module
+			bridgeModule := bridge.NewModule(config.Cfg, sources.BridgeSource, utils.GetCodec(), db)
+
+			// Get the accounts
+			// Collect all the transactions
+			var txs []*tmctypes.ResultTx
+
+			// Get all the MsgSendToXrpl txs
+			query := fmt.Sprintf(
+				"tx.height >= %d AND wasm._contract_address='%s' AND wasm.action='send_to_xrpl'",
+				startHeight,
+				bridgeCfg.ContractAddress,
+			)
+			sendToXrplTxs, err := utils.QueryTxs(parseCtx.Node, query)
+			if err != nil {
+				return err
+			}
+			txs = append(txs, sendToXrplTxs...)
+
+			// Get all the MsgSaveEvidence txs
+			query = fmt.Sprintf(
+				"tx.height >= %d AND wasm._contract_address='%s' AND wasm.action='save_evidence'",
+				startHeight,
+				bridgeCfg.ContractAddress,
+			)
+			saveEvidenceTxs, err := utils.QueryTxs(parseCtx.Node, query)
+			if err != nil {
+				return err
+			}
+			txs = append(txs, saveEvidenceTxs...)
+
+			// Sort the txs based on their ascending height
+			sort.Slice(txs, func(i, j int) bool {
+				return txs[i].Height < txs[j].Height
+			})
+
+			for _, tx := range txs {
+				log.Debug().Int64("height", tx.Height).Msg("parsing transaction")
+				transaction, err := parseCtx.Node.Tx(hex.EncodeToString(tx.Tx.Hash()))
+				if err != nil {
+					return err
+				}
+
+				for index := range transaction.Body.Messages {
+					err = bridgeModule.HandleMsg(index, transaction.Body.Messages[index], transaction)
+					if err != nil {
+						return fmt.Errorf("error while handling bridge module message: %s", err)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().Int64("start-height", 0, "Start height for filtering transactions (inclusive, 0 means no lower limit)")
+
+	return cmd
+}

--- a/cmd/parse/bridge/txs.go
+++ b/cmd/parse/bridge/txs.go
@@ -3,7 +3,9 @@ package bridge
 import (
 	"encoding/hex"
 	"fmt"
+	"os"
 	"sort"
+	"time"
 
 	tmctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/forbole/callisto/v4/database"
@@ -32,6 +34,50 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 				return err
 			}
 
+			endHeight, err := cmd.Flags().GetInt64("end-height")
+			if err != nil {
+				return err
+			}
+
+			splitHeight, err := cmd.Flags().GetInt64("split-height")
+			if err != nil {
+				return err
+			}
+
+			if splitHeight <= 0 {
+				splitHeight = 1000 // Default split height
+			}
+
+			// Create error log file
+			timestamp := time.Now().Format("2006-01-02_15-04-05")
+			errorLogFileName := fmt.Sprintf("bridge_errors_%d_%d_%s.log", startHeight, endHeight, timestamp)
+			errorLogFile, err := os.OpenFile(errorLogFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+			if err != nil {
+				return fmt.Errorf("failed to create error log file: %s", err)
+			}
+			defer errorLogFile.Close()
+
+			// Create summary log file
+			summaryLogFileName := fmt.Sprintf("bridge_summary_%d_%d_%s.log", startHeight, endHeight, timestamp)
+			summaryLogFile, err := os.OpenFile(summaryLogFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+			if err != nil {
+				return fmt.Errorf("failed to create summary log file: %s", err)
+			}
+			defer summaryLogFile.Close()
+
+			// Write header to summary log
+			headerMsg := "=== Bridge Transaction Processing Summary ===\n"
+			headerMsg += fmt.Sprintf("Start Height: %d\n", startHeight)
+			headerMsg += fmt.Sprintf("End Height: %d\n", endHeight)
+			headerMsg += fmt.Sprintf("Split Height: %d\n", splitHeight)
+			headerMsg += fmt.Sprintf("Started at: %s\n", time.Now().Format("2006-01-02 15:04:05"))
+			headerMsg += "============================================\n\n"
+			if _, err := summaryLogFile.WriteString(headerMsg); err != nil {
+				log.Error().Err(err).Msg("failed to write header to summary log file")
+			}
+
+			log.Info().Str("error_log", errorLogFileName).Str("summary_log", summaryLogFileName).Msg("log files created")
+
 			bz, err := config.Cfg.GetBytes()
 			if err != nil {
 				return err
@@ -52,59 +98,164 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 			// Build bridge module
 			bridgeModule := bridge.NewModule(config.Cfg, sources.BridgeSource, utils.GetCodec(), db)
 
-			// Get the accounts
-			// Collect all the transactions
-			var txs []*tmctypes.ResultTx
+			// Track overall statistics
+			totalTxsProcessed := 0
+			totalErrorsEncountered := 0
+			totalBlocksInserted := 0
 
-			// Get all the MsgSendToXrpl txs
-			query := fmt.Sprintf(
-				"tx.height >= %d AND wasm._contract_address='%s' AND wasm.action='send_to_xrpl'",
-				startHeight,
-				bridgeCfg.ContractAddress,
-			)
-			sendToXrplTxs, err := utils.QueryTxs(parseCtx.Node, query)
-			if err != nil {
-				return err
-			}
-			txs = append(txs, sendToXrplTxs...)
+			// Split the height range into chunks
+			for rangeStart := startHeight; rangeStart < endHeight; rangeStart += splitHeight {
+				rangeEnd := rangeStart + splitHeight
+				if rangeEnd > endHeight {
+					rangeEnd = endHeight
+				}
 
-			// Get all the MsgSaveEvidence txs
-			query = fmt.Sprintf(
-				"tx.height >= %d AND wasm._contract_address='%s' AND wasm.action='save_evidence'",
-				startHeight,
-				bridgeCfg.ContractAddress,
-			)
-			saveEvidenceTxs, err := utils.QueryTxs(parseCtx.Node, query)
-			if err != nil {
-				return err
-			}
-			txs = append(txs, saveEvidenceTxs...)
+				rangeStartTime := time.Now()
 
-			// Sort the txs based on their ascending height
-			sort.Slice(txs, func(i, j int) bool {
-				return txs[i].Height < txs[j].Height
-			})
+				log.Info().Int64("range_start", rangeStart).Int64("range_end", rangeEnd).
+					Msg("processing height range")
 
-			for _, tx := range txs {
-				log.Debug().Int64("height", tx.Height).Msg("parsing transaction")
-				transaction, err := parseCtx.Node.Tx(hex.EncodeToString(tx.Tx.Hash()))
+				// Track statistics for this range
+				rangeErrorCount := 0
+				rangeBlocksInserted := 0
+				rangeMessagesProcessed := 0
+
+				// Collect all the transactions for this range
+				var txs []*tmctypes.ResultTx
+
+				// Get all the MsgSendToXrpl txs
+				query := fmt.Sprintf(
+					"tx.height >= %d AND tx.height < %d AND wasm._contract_address='%s' AND wasm.action='send_to_xrpl'",
+					rangeStart,
+					rangeEnd,
+					bridgeCfg.ContractAddress,
+				)
+				sendToXrplTxs, err := utils.QueryTxs(parseCtx.Node, query)
 				if err != nil {
 					return err
 				}
+				txs = append(txs, sendToXrplTxs...)
 
-				for index := range transaction.Body.Messages {
-					err = bridgeModule.HandleMsg(index, transaction.Body.Messages[index], transaction)
+				// Get all the MsgSaveEvidence txs
+				query = fmt.Sprintf(
+					"tx.height >= %d AND tx.height < %d AND wasm._contract_address='%s' AND wasm.action='save_evidence'",
+					rangeStart,
+					rangeEnd,
+					bridgeCfg.ContractAddress,
+				)
+				saveEvidenceTxs, err := utils.QueryTxs(parseCtx.Node, query)
+				if err != nil {
+					return err
+				}
+				txs = append(txs, saveEvidenceTxs...)
+
+				log.Info().Int64("range_start", rangeStart).Int64("range_end", rangeEnd).
+					Int("tx_count", len(txs)).Msg("found transactions in range")
+
+				// Sort the txs based on their ascending height
+				sort.Slice(txs, func(i, j int) bool {
+					return txs[i].Height < txs[j].Height
+				})
+
+				for _, tx := range txs {
+					log.Debug().Int64("height", tx.Height).Msg("parsing transaction")
+
+					transaction, err := parseCtx.Node.Tx(hex.EncodeToString(tx.Tx.Hash()))
 					if err != nil {
-						return fmt.Errorf("error while handling bridge module message: %s", err)
+						return err
+					}
+
+					for index := range transaction.Body.Messages {
+						rangeMessagesProcessed++
+						err = bridgeModule.HandleMsg(index, transaction.Body.Messages[index], transaction)
+						if err != nil {
+							rangeErrorCount++
+							txHash := hex.EncodeToString(tx.Tx.Hash())
+							errorMsg := fmt.Sprintf("[%s] Height: %d | TxHash: %s | MsgIndex: %d | Error: %v\n",
+								time.Now().Format("2006-01-02 15:04:05"),
+								tx.Height,
+								txHash,
+								index,
+								err,
+							)
+
+							// Write to error log file
+							if _, writeErr := errorLogFile.WriteString(errorMsg); writeErr != nil {
+								log.Error().Err(writeErr).Msg("failed to write to error log file")
+							}
+
+							log.Error().Int64("height", tx.Height).Int("msg_index", index).
+								Str("tx_hash", txHash).
+								Err(err).Msg("error while handling bridge module message")
+							continue
+						}
 					}
 				}
+
+				// Calculate range duration
+				rangeDuration := time.Since(rangeStartTime)
+
+				// Update overall statistics
+				totalTxsProcessed += len(txs)
+				totalErrorsEncountered += rangeErrorCount
+				totalBlocksInserted += rangeBlocksInserted
+
+				// Write summary for this range
+				summaryMsg := fmt.Sprintf("--- Range: %d to %d ---\n", rangeStart, rangeEnd)
+				summaryMsg += fmt.Sprintf("Timestamp: %s\n", time.Now().Format("2006-01-02 15:04:05"))
+				summaryMsg += fmt.Sprintf("Duration: %s\n", rangeDuration.String())
+				summaryMsg += fmt.Sprintf("Transactions Found: %d\n", len(txs))
+				summaryMsg += fmt.Sprintf("Messages Processed: %d\n", rangeMessagesProcessed)
+				summaryMsg += fmt.Sprintf("Blocks Inserted: %d\n", rangeBlocksInserted)
+				summaryMsg += fmt.Sprintf("Errors Encountered: %d\n", rangeErrorCount)
+				if rangeMessagesProcessed > 0 {
+					successRate := float64(rangeMessagesProcessed-rangeErrorCount) / float64(rangeMessagesProcessed) * 100
+					summaryMsg += fmt.Sprintf("Success Rate: %.2f%%\n", successRate)
+				} else {
+					summaryMsg += "Success Rate: N/A (no messages processed)\n"
+				}
+				summaryMsg += "\n"
+
+				if _, err := summaryLogFile.WriteString(summaryMsg); err != nil {
+					log.Error().Err(err).Msg("failed to write to summary log file")
+				}
+
+				log.Info().Int64("range_start", rangeStart).Int64("range_end", rangeEnd).
+					Int("txs", len(txs)).Int("errors", rangeErrorCount).
+					Str("duration", rangeDuration.String()).
+					Msg("finished processing height range")
 			}
+
+			// Write final summary
+			rangeCount := (endHeight - startHeight + splitHeight - 1) / splitHeight
+
+			finalSummary := "============================================\n"
+			finalSummary += "=== Final Summary ===\n"
+			finalSummary += fmt.Sprintf("Completed at: %s\n", time.Now().Format("2006-01-02 15:04:05"))
+			finalSummary += fmt.Sprintf("Total Ranges Processed: %d\n", rangeCount)
+			finalSummary += fmt.Sprintf("Total Transactions Processed: %d\n", totalTxsProcessed)
+			finalSummary += fmt.Sprintf("Total Blocks Inserted: %d\n", totalBlocksInserted)
+			finalSummary += fmt.Sprintf("Total Errors Encountered: %d\n", totalErrorsEncountered)
+			finalSummary += "============================================\n"
+
+			if _, err := summaryLogFile.WriteString(finalSummary); err != nil {
+				log.Error().Err(err).Msg("failed to write final summary to log file")
+			}
+
+			log.Info().
+				Str("error_log", errorLogFileName).
+				Str("summary_log", summaryLogFileName).
+				Int("total_txs", totalTxsProcessed).
+				Int("total_errors", totalErrorsEncountered).
+				Msg("processing complete")
 
 			return nil
 		},
 	}
 
 	cmd.Flags().Int64("start-height", 0, "Start height for filtering transactions (inclusive, 0 means no lower limit)")
+	cmd.Flags().Int64("end-height", 0, "End height for filtering transactions (exclusive, 0 means no upper limit)")
+	cmd.Flags().Int64("split-height", 100000, "Height range to split processing into chunks (default: 1000)")
 
 	return cmd
 }

--- a/cmd/parse/bridge/txs.go
+++ b/cmd/parse/bridge/txs.go
@@ -38,18 +38,18 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 				return err
 			}
 
-			splitHeight, err := cmd.Flags().GetInt64("split-height")
+			checkSize, err := cmd.Flags().GetInt64("check-size")
 			if err != nil {
 				return err
 			}
 
-			if splitHeight <= 0 {
-				splitHeight = 1000 // Default split height
+			if checkSize <= 0 {
+				checkSize = 1000 // Default check size
 			}
 
 			// Log processing summary header
 			log.Info().Msg("=== Bridge Transaction Processing Summary ===")
-			log.Info().Int64("start_height", startHeight).Int64("end_height", endHeight).Int64("split_height", splitHeight).Msg("starting bridge transaction processing")
+			log.Info().Int64("start_height", startHeight).Int64("end_height", endHeight).Int64("check_size", checkSize).Msg("starting bridge transaction processing")
 
 			bz, err := config.Cfg.GetBytes()
 			if err != nil {
@@ -77,8 +77,8 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 			totalBlocksInserted := 0
 
 			// Split the height range into chunks
-			for rangeStart := startHeight; rangeStart < endHeight; rangeStart += splitHeight {
-				rangeEnd := rangeStart + splitHeight
+			for rangeStart := startHeight; rangeStart < endHeight; rangeStart += checkSize {
+				rangeEnd := rangeStart + checkSize
 				if rangeEnd > endHeight {
 					rangeEnd = endHeight
 				}
@@ -182,7 +182,7 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 			}
 
 			// Log final summary
-			rangeCount := (endHeight - startHeight + splitHeight - 1) / splitHeight
+			rangeCount := (endHeight - startHeight + checkSize - 1) / checkSize
 
 			log.Info().Msg("============================================")
 			log.Info().Msg("=== Final Summary ===")
@@ -200,7 +200,7 @@ func txsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 
 	cmd.Flags().Int64("start-height", 0, "Start height for filtering transactions (inclusive, 0 means no lower limit)")
 	cmd.Flags().Int64("end-height", 0, "End height for filtering transactions (exclusive, 0 means no upper limit)")
-	cmd.Flags().Int64("split-height", 100000, "Height range to split processing into chunks (default: 1000)")
+	cmd.Flags().Int64("check-size", 100000, "Size of the height range to check (default: 100000)")
 
 	return cmd
 }

--- a/cmd/parse/parse.go
+++ b/cmd/parse/parse.go
@@ -3,6 +3,7 @@ package parse
 import (
 	parseauth "github.com/forbole/callisto/v4/cmd/parse/auth"
 	parsebank "github.com/forbole/callisto/v4/cmd/parse/bank"
+	parsebridge "github.com/forbole/callisto/v4/cmd/parse/bridge"
 	parsedex "github.com/forbole/callisto/v4/cmd/parse/dex"
 	parsedistribution "github.com/forbole/callisto/v4/cmd/parse/distribution"
 	parsefeegrant "github.com/forbole/callisto/v4/cmd/parse/feegrant"
@@ -39,6 +40,7 @@ func NewParseCmd(parseCfg *parse.Config, parser messages.MessageAddressesParser)
 		parsestaking.NewStakingCmd(parseCfg),
 		parsetransaction.NewTransactionsCmd(parseCfg),
 		parsedex.NewDexCmd(parseCfg),
+		parsebridge.NewBridgeCmd(parseCfg),
 	)
 
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	cosmossdk.io/x/feegrant v0.1.1
 	cosmossdk.io/x/nft v0.1.1
 	cosmossdk.io/x/upgrade v0.1.4
+	github.com/CoreumFoundation/coreum-tools v0.4.1-0.20241202115740-dbc6962a4d0a
 	github.com/CoreumFoundation/coreum/v5 v5.0.0-20250526103302-5a3f05b11008
 	github.com/CoreumFoundation/coreumbridge-xrpl/relayer v0.0.0-20250526113311-5229bda4c986
 	github.com/CosmWasm/wasmd v0.54.0
@@ -51,7 +52,6 @@ require (
 	github.com/Antonboom/errname v0.1.9 // indirect
 	github.com/Antonboom/nilnil v0.1.3 // indirect
 	github.com/BurntSushi/toml v1.4.0 // indirect
-	github.com/CoreumFoundation/coreum-tools v0.4.1-0.20241202115740-dbc6962a4d0a // indirect
 	github.com/CosmWasm/wasmvm/v2 v2.2.2 // indirect
 	github.com/DataDog/datadog-go v4.8.3+incompatible // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 replace (
 	// Coreum verison of the juno module
-	github.com/forbole/juno/v6 => github.com/CoreumFoundation/juno/v6 v6.0.0-20251001165459-6c6142c7501d
+	github.com/forbole/juno/v6 => github.com/CoreumFoundation/juno/v6 v6.0.0-20250925134141-d664933a619c
 	// https://github.com/cosmos/cosmos-sdk/issues/14949
 	// pin the version of goleveldb to v1.0.1-0.20210819022825-2ae1ddf74ef7 required by SDK v47 upgrade guide.
 	// replace broken goleveldb

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 replace (
 	// Coreum verison of the juno module
-	github.com/forbole/juno/v6 => github.com/CoreumFoundation/juno/v6 v6.0.0-20250925134141-d664933a619c
+	github.com/forbole/juno/v6 => github.com/CoreumFoundation/juno/v6 v6.0.0-20251001165459-6c6142c7501d
 	// https://github.com/cosmos/cosmos-sdk/issues/14949
 	// pin the version of goleveldb to v1.0.1-0.20210819022825-2ae1ddf74ef7 required by SDK v47 upgrade guide.
 	// replace broken goleveldb

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/CoreumFoundation/coreum/v5 v5.0.0-20250526103302-5a3f05b11008 h1:zuNt
 github.com/CoreumFoundation/coreum/v5 v5.0.0-20250526103302-5a3f05b11008/go.mod h1:LQbK4qqr0E1icUCcQT464isJfMeW2mybvX6XXkTpeGI=
 github.com/CoreumFoundation/coreumbridge-xrpl/relayer v0.0.0-20250526113311-5229bda4c986 h1:80MHeVs1eJ5NWSeMpfXZOVXkfbOfPlATbeu6FPNI/OY=
 github.com/CoreumFoundation/coreumbridge-xrpl/relayer v0.0.0-20250526113311-5229bda4c986/go.mod h1:2l9vGnucwn0hTIOWX2j91Aevykac8CowIhgMTJhp/N4=
-github.com/CoreumFoundation/juno/v6 v6.0.0-20250925134141-d664933a619c h1:5s3FBH1uwwoPZhAqayTev4/ubjNAN1YmkLUAz0DQoGg=
-github.com/CoreumFoundation/juno/v6 v6.0.0-20250925134141-d664933a619c/go.mod h1:j6HuUZvZJHPYpkMY7s+tGDE1xnYRzkvgQSgpMF2ZCTw=
+github.com/CoreumFoundation/juno/v6 v6.0.0-20251001165459-6c6142c7501d h1://M2yBPEy1+4kmy/7YMwMEewDmQJNPaUxJCZ9szLDr8=
+github.com/CoreumFoundation/juno/v6 v6.0.0-20251001165459-6c6142c7501d/go.mod h1:j6HuUZvZJHPYpkMY7s+tGDE1xnYRzkvgQSgpMF2ZCTw=
 github.com/CosmWasm/wasmd v0.54.0 h1:/txsBehV1xnAi46H1xwuuY6D4NySujBy+wa5+ryItS8=
 github.com/CosmWasm/wasmd v0.54.0/go.mod h1:8Zu/rj6RHbJ8Gx0WdqsGeHvgnEQb0rqchpqhgMxASRU=
 github.com/CosmWasm/wasmvm/v2 v2.2.2 h1:MaQMtaZN8L08N0uAlBlOICP+GWolibJsajHGo3fQ03w=

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/CoreumFoundation/coreum/v5 v5.0.0-20250526103302-5a3f05b11008 h1:zuNt
 github.com/CoreumFoundation/coreum/v5 v5.0.0-20250526103302-5a3f05b11008/go.mod h1:LQbK4qqr0E1icUCcQT464isJfMeW2mybvX6XXkTpeGI=
 github.com/CoreumFoundation/coreumbridge-xrpl/relayer v0.0.0-20250526113311-5229bda4c986 h1:80MHeVs1eJ5NWSeMpfXZOVXkfbOfPlATbeu6FPNI/OY=
 github.com/CoreumFoundation/coreumbridge-xrpl/relayer v0.0.0-20250526113311-5229bda4c986/go.mod h1:2l9vGnucwn0hTIOWX2j91Aevykac8CowIhgMTJhp/N4=
-github.com/CoreumFoundation/juno/v6 v6.0.0-20251001165459-6c6142c7501d h1://M2yBPEy1+4kmy/7YMwMEewDmQJNPaUxJCZ9szLDr8=
-github.com/CoreumFoundation/juno/v6 v6.0.0-20251001165459-6c6142c7501d/go.mod h1:j6HuUZvZJHPYpkMY7s+tGDE1xnYRzkvgQSgpMF2ZCTw=
+github.com/CoreumFoundation/juno/v6 v6.0.0-20250925134141-d664933a619c h1:5s3FBH1uwwoPZhAqayTev4/ubjNAN1YmkLUAz0DQoGg=
+github.com/CoreumFoundation/juno/v6 v6.0.0-20250925134141-d664933a619c/go.mod h1:j6HuUZvZJHPYpkMY7s+tGDE1xnYRzkvgQSgpMF2ZCTw=
 github.com/CosmWasm/wasmd v0.54.0 h1:/txsBehV1xnAi46H1xwuuY6D4NySujBy+wa5+ryItS8=
 github.com/CosmWasm/wasmd v0.54.0/go.mod h1:8Zu/rj6RHbJ8Gx0WdqsGeHvgnEQb0rqchpqhgMxASRU=
 github.com/CosmWasm/wasmvm/v2 v2.2.2 h1:MaQMtaZN8L08N0uAlBlOICP+GWolibJsajHGo3fQ03w=

--- a/utils/node.go
+++ b/utils/node.go
@@ -2,22 +2,98 @@ package utils
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/forbole/juno/v6/node"
+	"github.com/rs/zerolog/log"
 )
 
+// isRetryableError checks if an error is retryable (timeout, gateway error, etc.)
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errMsg := err.Error()
+	retryableErrors := []string{
+		"504 Gateway Time-out",
+		"503 Service Unavailable",
+		"502 Bad Gateway",
+		"timeout",
+		"connection refused",
+		"connection reset",
+		"EOF",
+		"invalid character '<'", // HTML error pages
+	}
+
+	for _, retryable := range retryableErrors {
+		if strings.Contains(errMsg, retryable) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // QueryTxs queries all the transactions from the given node corresponding to the given query
+// with retry logic for transient errors like timeouts
 func QueryTxs(node node.Node, query string) ([]*coretypes.ResultTx, error) {
 	var txs []*coretypes.ResultTx
 
 	page := 1
 	perPage := 100
 	stop := false
+
+	const maxRetries = 10
+	const initialBackoff = 1 * time.Second
+	const maxBackoff = 1024 * time.Second
+
 	for !stop {
-		result, err := node.TxSearch(query, &page, &perPage, "")
+		var result *coretypes.ResultTxSearch
+		var err error
+
+		// Retry logic with exponential backoff
+		for attempt := 0; attempt < maxRetries; attempt++ {
+			result, err = node.TxSearch(query, &page, &perPage, "")
+
+			if err == nil {
+				// Success, break out of retry loop
+				break
+			}
+
+			// Check if error is retryable
+			if !isRetryableError(err) {
+				// Non-retryable error, return immediately
+				return nil, fmt.Errorf("error while running tx search: %s", err)
+			}
+
+			// Don't wait after the last attempt
+			if attempt == maxRetries-1 {
+				break
+			}
+
+			// Calculate backoff duration with exponential backoff: 1s, 2s, 4s, 8s, 16s, 32s
+			backoff := initialBackoff * time.Duration(1<<uint(attempt))
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+
+			log.Warn().
+				Int("attempt", attempt+1).
+				Int("max_retries", maxRetries).
+				Dur("backoff", backoff).
+				Err(err).
+				Msg("retryable error in tx search, retrying after backoff")
+
+			// Wait before retrying (exponential backoff)
+			time.Sleep(backoff)
+		}
+
+		// If still error after all retries, return error
 		if err != nil {
-			return nil, fmt.Errorf("error while running tx search: %s", err)
+			return nil, fmt.Errorf("error while running tx search after %d retries: %s", maxRetries, err)
 		}
 
 		page++

--- a/utils/node.go
+++ b/utils/node.go
@@ -1,44 +1,17 @@
 package utils
 
 import (
+	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/forbole/juno/v6/node"
-	"github.com/rs/zerolog/log"
+
+	"github.com/CoreumFoundation/coreum-tools/pkg/retry"
 )
 
-// isRetryableError checks if an error is retryable (timeout, gateway error, etc.)
-func isRetryableError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errMsg := err.Error()
-	retryableErrors := []string{
-		"504 Gateway Time-out",
-		"503 Service Unavailable",
-		"502 Bad Gateway",
-		"timeout",
-		"connection refused",
-		"connection reset",
-		"EOF",
-		"invalid character '<'", // HTML error pages
-	}
-
-	for _, retryable := range retryableErrors {
-		if strings.Contains(errMsg, retryable) {
-			return true
-		}
-	}
-
-	return false
-}
-
 // QueryTxs queries all the transactions from the given node corresponding to the given query
-// with retry logic for transient errors like timeouts
 func QueryTxs(node node.Node, query string) ([]*coretypes.ResultTx, error) {
 	var txs []*coretypes.ResultTx
 
@@ -46,54 +19,27 @@ func QueryTxs(node node.Node, query string) ([]*coretypes.ResultTx, error) {
 	perPage := 100
 	stop := false
 
-	const maxRetries = 10
-	const initialBackoff = 1 * time.Second
-	const maxBackoff = 1024 * time.Second
+	ctx := context.Background()
+	retryDelay := 500 * time.Millisecond
+	doTimeout := 60 * time.Second
 
 	for !stop {
 		var result *coretypes.ResultTxSearch
-		var err error
+		var searchErr error
 
-		// Retry logic with exponential backoff
-		for attempt := 0; attempt < maxRetries; attempt++ {
-			result, err = node.TxSearch(query, &page, &perPage, "")
-
-			if err == nil {
-				// Success, break out of retry loop
-				break
+		// Retry logic for each page
+		doCtx, doCtxCancel := context.WithTimeout(ctx, doTimeout)
+		err := retry.Do(doCtx, retryDelay, func() error {
+			result, searchErr = node.TxSearch(query, &page, &perPage, "")
+			if searchErr != nil {
+				return fmt.Errorf("error while running tx search: %s", searchErr)
 			}
+			return nil
+		})
+		doCtxCancel()
 
-			// Check if error is retryable
-			if !isRetryableError(err) {
-				// Non-retryable error, return immediately
-				return nil, fmt.Errorf("error while running tx search: %s", err)
-			}
-
-			// Don't wait after the last attempt
-			if attempt == maxRetries-1 {
-				break
-			}
-
-			// Calculate backoff duration with exponential backoff: 1s, 2s, 4s, 8s, 16s, 32s
-			backoff := initialBackoff * time.Duration(1<<uint(attempt))
-			if backoff > maxBackoff {
-				backoff = maxBackoff
-			}
-
-			log.Warn().
-				Int("attempt", attempt+1).
-				Int("max_retries", maxRetries).
-				Dur("backoff", backoff).
-				Err(err).
-				Msg("retryable error in tx search, retrying after backoff")
-
-			// Wait before retrying (exponential backoff)
-			time.Sleep(backoff)
-		}
-
-		// If still error after all retries, return error
 		if err != nil {
-			return nil, fmt.Errorf("error while running tx search after %d retries: %s", maxRetries, err)
+			return nil, err
 		}
 
 		page++


### PR DESCRIPTION
## Description

This pull request introduces a new set of commands for managing and re-parsing bridge module transactions, along with improvements to error handling and logging. The main changes add a new `bridge` command with a subcommand for re-scanning bridge transactions, integrate it into the main parse CLI, and enhance the reliability of transaction querying with retry logic for transient errors.

**New Bridge Module Commands:**

* Added a new `bridge` command to the CLI, with a `txs` subcommand that allows re-scanning and overwriting all bridge transactions within a specified block height range. This includes chunked processing, detailed error and summary logging, and statistics tracking. 

**Integration with Parse CLI:**

* Registered the new `bridge` command in the main parse CLI, making it available alongside other module commands.

**Reliability and Error Handling Improvements:**

* Enhanced the `QueryTxs` utility function to include retry logic with exponential backoff for transient errors (timeouts, gateway errors, etc.), improving robustness when querying transactions from the node.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/callisto/101)
<!-- Reviewable:end -->
